### PR TITLE
Removed scope from being passed to the treePicker dialog service

### DIFF
--- a/urlpicker/app/scripts/controllers/url.picker.controller.js
+++ b/urlpicker/app/scripts/controllers/url.picker.controller.js
@@ -22,7 +22,6 @@ angular.module('umbraco').controller('UrlPickerController', function($scope, dia
   	var ds = dialogService.treePicker({
   		section: type,
   		treeAlias: type,
-  		scope: $scope,
   	    startNodeId: getStartNodeId(type),
   		multiPicker: false,
   		callback: function(data) {

--- a/urlpicker/config/package.xml
+++ b/urlpicker/config/package.xml
@@ -7,9 +7,9 @@
       <license url="<%= licenseUrl %>"><%= license %></license>
       <url><%= url %></url>
       <requirements>
-        <major>0</major>
-        <minor>0</minor>
-        <patch>0</patch>
+        <major>7</major>
+        <minor>1</minor>
+        <patch>3</patch>
       </requirements>
     </package>
     <author>

--- a/urlpicker/package.json
+++ b/urlpicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "UrlPicker",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Url Picker Property Editor from uWestFest",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
Removed scope from being passed to the treePicker dialog service as it is now destroyed. More info on the issue here http://issues.umbraco.org/issue/U4-4979

*\* This now means that Umbraco v7.1.3 min required version for this package **
