### PR TITLE
Extra null check when initialising the Url Picker

### DIFF
--- a/urlpicker/app/scripts/controllers/url.picker.controller.js
+++ b/urlpicker/app/scripts/controllers/url.picker.controller.js
@@ -66,11 +66,11 @@ angular.module('umbraco').controller('UrlPickerController', function($scope, dia
 
     $scope.model.value = $scope.model.value || { "type": "url", "meta" : { "title" : "", "newWindow" : true },"typeData": {"url" : "", "contentId" : null, "mediaId" : null} };
 
-    if($scope.model.value.typeData.contentId) {
+    if ($scope.model.value.typeData && $scope.model.value.typeData.contentId) {
       $scope.contentName = getEntityName($scope.model.value.typeData.contentId, "Document");
     }
 
-    if($scope.model.value.typeData.mediaId) {
+    if ($scope.model.value.typeData && $scope.model.value.typeData.mediaId) {
       $scope.mediaName =  getEntityName($scope.model.value.typeData.mediaId, "Media");
     }
   }


### PR DESCRIPTION
If a property already exists with a value, after changing it's type to the Url Picker, the value object may not be in a format the Url Picker knows about. For example, changing a property from a Content Picker to a Url Picker.
