### PR TITLE
Extra init check to make sure value has the correct type

### DIFF
--- a/urlpicker/app/scripts/controllers/url.picker.controller.js
+++ b/urlpicker/app/scripts/controllers/url.picker.controller.js
@@ -64,8 +64,10 @@ angular.module('umbraco').controller('UrlPickerController', function($scope, dia
     if (!$scope.model.config.mediaStartNode)
         $scope.model.config.mediaStartNode = -1;
 
-    $scope.model.value = $scope.model.value || { "type": "url", "meta" : { "title" : "", "newWindow" : true },"typeData": {"url" : "", "contentId" : null, "mediaId" : null} };
-
+    if (!$scope.model.value || !$scope.model.value.type) {
+        $scope.model.value = { "type": "url", "meta": { "title": "", "newWindow": true }, "typeData": { "url": "", "contentId": null, "mediaId": null } };
+    }
+    
     if($scope.model.value.typeData.contentId) {
       $scope.contentName = getEntityName($scope.model.value.typeData.contentId, "Document");
     }


### PR DESCRIPTION
Along with issue #10, a valid Url Picker value must have a type object. If a property has been converted and has a value, the value object may not be in the correct format. To fix, look to see if we have a type object in the value object. If not, initialise as new.
