### PR TITLE
Close existing dialog + use mediaPicker

### DIFF
--- a/urlpicker/app/scripts/controllers/url.picker.controller.js
+++ b/urlpicker/app/scripts/controllers/url.picker.controller.js
@@ -107,6 +107,19 @@ angular.module('umbraco').controller('UrlPickerController', function($scope, dia
     }
     else {
       $scope.model.config.mediaPreview = true;
+
+      var mediaId = $scope.model.value.typeData.mediaId;
+
+      if(mediaId) {
+        entityResource.getById(mediaId, "Media").then(function (media) {
+          if (!media.thumbnail) { 
+              media.thumbnail = mediaHelper.resolveFileFromEntity(media, true);
+          }
+
+          $scope.media = media;
+        });
+        //Todo: handle scenario where selected media has been deleted
+      }
     }
 
     if (!$scope.model.value || !$scope.model.value.type) {

--- a/urlpicker/app/styles/url.picker.less
+++ b/urlpicker/app/styles/url.picker.less
@@ -45,4 +45,33 @@
     .url-delete{
 	  margin-top: 5px;
 	}
+	.thumbnail {
+	    width: 120px;
+	    height: 100px;
+	    overflow: hidden;
+	    position: relative;
+	    display: block;
+	    padding: 2px;
+	    margin: 5px;
+	    text-align: center;
+	    vertical-align: top;
+	    background: white;
+	    border: 1px solid #f8f8f8;
+	    
+	    img {
+	        display: block;
+	        max-width: 100%;
+	        max-height: 100%;
+	        margin: auto;
+	        background-image: url(/umbraco/assets/img/checkered-background.png);
+	    }
+	}
+	
+	.icon-holder .icon {
+	    display: block;
+	    font-size: 60px;
+	    line-height: 70px;
+	}
+
+
 }

--- a/urlpicker/app/views/url.picker.html
+++ b/urlpicker/app/views/url.picker.html
@@ -34,7 +34,17 @@
 		<div ng-show="model.value.type == 'media'">
 			<a ng-click="openTreePicker('media')" prevent-default>Select…</a>
 			{{mediaName}}
-            <a href class="delete-icon" ng-click="resetType('media')" ng-show="model.value.typeData.mediaId > 0"><i class="icon icon-delete"></i></a>
+
+			<a href class="delete-icon" ng-click="resetType('media')" ng-show="model.value.typeData.mediaId > 0"><i class="icon icon-delete"></i></a>
+
+			<div class="thumbnail" ng-show="model.config.mediaPreview">
+				<img ng-src="{{media.thumbnail}}" alt="" ng-show="media.thumbnail">
+				
+				<span class="icon-holder" ng-hide="media.thumbnail">
+					<i class="icon {{media.icon}} large" ></i>
+					<small>{{media.name}}</small>
+				</span>
+			</div>
 		</div>
 	</div>
 

--- a/urlpicker/config/package.manifest
+++ b/urlpicker/config/package.manifest
@@ -22,6 +22,18 @@
     				view: "mediapicker"
     			},
           {
+            label: "Only images from media",
+            description: "Only let the editor choose images from media",
+            key: "mediaImagesOnly",
+            view: "boolean"
+          },
+          {
+            label: "Media preview",
+            description: "Use thumbnail preview for media",
+            key: "mediaPreview",
+            view: "boolean"
+          },
+          {
             label: "Hide Title",
             description: "Hides the title field",
             key: "hideTitle",


### PR DESCRIPTION
Close existing dialog before opening a new one and use media picker for
media instead of just the treepicker.

Furthermore I have added to option if the editor only should be allowed
to pick images in media picker and if it should display a preview of the
selected media.

Fix issues #18 and #23 

I have found some inspiration from the core multiple mediapicker and tried to make it consistent.
https://github.com/umbraco/Umbraco-CMS/tree/7c4a189aa3cf583954defd9c43a3e55e325f2c3f/src/Umbraco.Web.UI.Client/src/views/propertyeditors/mediapicker

![image](https://cloud.githubusercontent.com/assets/2919859/9705222/07f31a96-54be-11e5-9a44-2c120dd4eef7.png)

![image](https://cloud.githubusercontent.com/assets/2919859/9705231/1f4da42c-54be-11e5-9427-a2a85638fc13.png)